### PR TITLE
nix: use fenix to provide the correct version of the rust tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /target
+
+# Nix-related files
+/result
+/profile
+/profile-*

--- a/default.nix
+++ b/default.nix
@@ -2,10 +2,21 @@
   pkgs,
   lib,
   stdenv,
+  fenix,
 }: let
   manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+  toolchain =
+    fenix.fromToolchainFile
+    {
+      file = ./rust-toolchain.toml;
+      sha256 = "sha256-6eN/GKzjVSjEhGO9FhWObkRFaE1Jf+uqMSdQnb8lcB4=";
+    };
 in
-  pkgs.rustPlatform.buildRustPackage {
+  (pkgs.makeRustPlatform {
+    cargo = toolchain;
+    rustc = toolchain;
+  })
+  .buildRustPackage {
     pname = manifest.name;
     version = manifest.version;
     cargoLock.lockFile = ./Cargo.lock;

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1722839439,
+        "narHash": "sha256-AwQv9kstzEOYjzuC9uY8jECqFJPuV/UxPLa30L3DLqo=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "1388e72dd8562c8b2908fd655dee0c797df9e930",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1722630782,
@@ -18,7 +39,25 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1722798820,
+        "narHash": "sha256-/Bd0VzlutcxTwSNouS/iC6BDv395NoO4XmBJaS2vQLg=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "c9109f23de57359df39db6fa36b5ca4c64b671e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,23 +2,32 @@
   description = "git-sidequest";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
+    fenix,
   }: let
     pkgsFor = nixpkgs.legacyPackages;
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "x86_64-darwin" "aarch64-linux"];
   in {
     packages = forAllSystems (
       system: {
-        default = pkgsFor.${system}.callPackage ./default.nix {};
+        default = pkgsFor.${system}.callPackage ./default.nix {
+          fenix = fenix.packages.${system};
+        };
       }
     );
     devShells = forAllSystems (
       system: {
-        default = pkgsFor.${system}.callPackage ./shell.nix {};
+        default = pkgsFor.${system}.callPackage ./shell.nix {
+          fenix = fenix.packages.${system};
+        };
       }
     );
   };

--- a/justfile
+++ b/justfile
@@ -8,13 +8,27 @@ check:
 # Build the dev version of the app
 build:
     cargo build
+# Run the test suite
+test:
+    bats ./tests/*
 # Build the release version of the app
 release:
     cargo build --release
 # Build and install the app to $HOME/.cargo/bin
 install:
     cargo install --path .
+# Update the package dependencies
+update-deps:
+    cargo update
+# Update the flake inputs
+update-flake:
+    nix flake update
+# Enter the DevShell of the project, and add it to the GCroots
+activate:
+    nix develop --profile ./profile --command zsh
 # Remove build artifacts
 clean:
     cargo clean
     rm -f result
+    rm -f profile
+    rm -f profile-*

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
+profile = "minimal"

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,9 @@
-{pkgs}:
+{
+  pkgs,
+  fenix,
+}:
 pkgs.mkShell {
-  inputsFrom = [(pkgs.callPackage ./default.nix {})];
+  inputsFrom = [(pkgs.callPackage ./default.nix {fenix = fenix;})];
   packages = with pkgs; [
     bats
     just


### PR DESCRIPTION
# Description

- Add Nix artifacts to the `.gitignore`
- Use nix-community/fenix to provide the Rust toolchain
- Add some `justfile` target
- Bump rust to `1.80.0`