### PR TITLE
chore: version 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "git-sidequest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-sidequest"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 repository = "https://github.com/AdrienCos/git-sidequest"
 license = "MIT"


### PR DESCRIPTION
## Changelog

- Use Bats to run the e2e test
- Use Fenix to install the install the correct toolchain in the Nix context
- Configure `cargo-dist` to build and release the new versions of this tool
