### PR TITLE
feat: rework error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +132,7 @@ dependencies = [
 name = "git-sidequest"
 version = "0.5.3"
 dependencies = [
+ "anyhow",
  "clap",
  "git2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/AdrienCos/git-sidequest"
 license = "MIT"
 
 [dependencies]
+anyhow = "1.0.86"
 clap = { version = "4.5.8", features = ["derive"] }
 git2 = { version = "0.19.0", features = [
     "ssh_key_from_memory",

--- a/src/app.rs
+++ b/src/app.rs
@@ -110,20 +110,9 @@ impl App {
     }
 
     fn create_branch(&self, branch: &str, target: &str) -> Result<()> {
-        let (_, reference) = self.repo.revparse_ext(target)?;
-
-        // Create target branch
-        Ok(self
-            .repo
-            .branch(
-                branch,
-                &self
-                    .repo
-                    .find_commit(reference.unwrap().target().unwrap())
-                    .unwrap(),
-                false,
-            )
-            .map(|_| ())?)
+        let target_commit = self.repo.find_reference(target)?.peel_to_commit()?;
+        self.repo.branch(branch, &target_commit, false)?;
+        Ok(())
     }
 
     fn get_current_branch_name(&self) -> Result<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all, clippy::pedantic, clippy::style)]
 
-use std::process::exit;
-
+use anyhow::{bail, Result};
 use clap::Parser;
 mod app;
 mod constants;
@@ -23,7 +22,7 @@ struct Args {
 }
 
 #[allow(clippy::too_many_lines)]
-fn main() {
+fn main() -> Result<()> {
     let args = Args::parse();
 
     println!("Sidequest started: {}", args.branch);
@@ -38,8 +37,7 @@ fn main() {
     let signature = match app.default_signature() {
         Ok(sign) => sign,
         Err(e) => {
-            eprint!("Sidequest failed: {e}");
-            return;
+            bail!(e);
         }
     };
 
@@ -49,10 +47,10 @@ fn main() {
     match app.run(&args.branch, &args.onto, Some(&signature), message) {
         Ok(()) => {
             println!("Sidequest successful!");
+            Ok(())
         }
         Err(e) => {
-            eprintln!("Sidequest failed: {e}");
-            exit(1);
+            bail!(e);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,13 @@
-#![warn(clippy::all, clippy::pedantic, clippy::style)]
+#![warn(
+    clippy::all,
+    clippy::pedantic,
+    clippy::style,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::Parser;
 mod app;
 mod constants;
@@ -28,7 +35,7 @@ fn main() -> Result<()> {
     println!("Sidequest started: {}", args.branch);
 
     // Check if we are in a git repo
-    let repo = utils::open_repository().unwrap();
+    let repo = utils::open_repository().context("No valid Git repository found")?;
 
     // Instantiate the app
     let mut app = app::App::new(repo);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,13 @@
+use anyhow::{anyhow, Result};
 use git2::Repository;
 
-pub fn validate_branch_name(branch_name: &str) -> Result<String, String> {
+pub fn validate_branch_name(branch_name: &str) -> Result<String> {
     match git2::Branch::name_is_valid(branch_name) {
         Ok(true) => Ok(branch_name.to_string()),
-        _ => Err("Invalid branch name".to_string()),
+        _ => Err(anyhow!("Invalid branch name")),
     }
 }
 
-pub fn open_repository() -> Result<Repository, git2::Error> {
-    Repository::discover(".")
+pub fn open_repository() -> Result<Repository> {
+    Ok(Repository::discover(".")?)
 }

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -93,7 +93,7 @@ setup() {
 @test "aborts if the repo is currently in a rebase operation" {
     # Manually force a merge conflict during the rebase
     git add .
-    git commit -m "This commit creates a conflict"
+    git commit -m "This commit creates a conflict" --quiet
     run git rebase conflict-branch
     run $EXE_PATH sidequest-branch -m "This should not be commited"
     assert_failure

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -71,6 +71,14 @@ setup() {
     assert_output --partial "Sidequest successful!"
 }
 
+@test "can run from a directory inside the Git repository" {
+    mkdir nested
+    cd nested
+    run $EXE_PATH sidequest-branch -m "Commit message for onto-branch sidequest"
+    assert_success
+    assert_output --partial "Sidequest successful!"
+}
+
 @test "aborts if no changes are staged" {
     git restore --staged .
     run $EXE_PATH sidequest-branch -m "This should not be commited"
@@ -113,4 +121,11 @@ setup() {
     run $EXE_PATH ..sidequest-branch -m "This should not be commited"
     assert_failure
     assert_output --partial "Invalid branch name"
+}
+
+@test "aborts if the current directory is not a git repo" {
+    mv .git .not-git
+    run $EXE_PATH sidequest-branch -m "This should not be commited"
+    assert_failure
+    assert_output --partial "No valid Git repository found"
 }


### PR DESCRIPTION
## Descriptions

- Add crate `anyhow`
- Replace all the instances of `std::Result` with `anyhow::Result`
- Remove the `SidequestError` enum
- Silence a log in the e2e tests