### PR TITLE
build: use oxalica/rust-overlay and crane for Nix builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,32 +2,34 @@
   pkgs,
   lib,
   stdenv,
-  fenix,
+  crane,
 }: let
-  manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
-  toolchain =
-    fenix.fromToolchainFile
-    {
-      file = ./rust-toolchain.toml;
-      sha256 = "sha256-6eN/GKzjVSjEhGO9FhWObkRFaE1Jf+uqMSdQnb8lcB4=";
-    };
-in
-  (pkgs.makeRustPlatform {
-    cargo = toolchain;
-    rustc = toolchain;
-  })
-  .buildRustPackage {
-    pname = manifest.name;
-    version = manifest.version;
-    cargoLock.lockFile = ./Cargo.lock;
-    doCheck = false;
-    src = pkgs.lib.cleanSource ./.;
-    nativeBuildInputs = [
-      pkgs.pkg-config
-    ];
+  # Parse the toolchain.toml file to build a toolchain with the correct Rust
+  # tools versions
+  toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+  # Setup crane with the toolchain built above
+  craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
+  # Arguments used when building both the dependencies and the final binary
+  commonArgs = {
+    src = craneLib.cleanCargoSource ./.;
+    strictDeps = true;
     buildInputs =
       []
       ++ lib.optionals stdenv.isDarwin [
         pkgs.darwin.apple_sdk.frameworks.Security
       ];
-  }
+    nativeBuildInputs = [
+      pkgs.pkg-config
+    ];
+  };
+  # Arguments specific to the final build, can be changed without causing a full
+  # rebuild of all the dependencies.
+  buildArgs = {};
+in
+  craneLib.buildPackage (
+    commonArgs
+    // buildArgs
+    // {
+      cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+    }
+  )

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,17 @@
 {
   "nodes": {
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
+    "crane": {
       "locked": {
-        "lastModified": 1734849150,
-        "narHash": "sha256-mgCcRp22vKy+ZoMKn7DG4UBK0iiZTy2reyFA/YCxVLI=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "6c2c568c407a0489295194900be09e75c6603a25",
+        "lastModified": 1734808813,
+        "narHash": "sha256-3aH/0Y6ajIlfy7j52FGZ+s4icVX0oHhqBzRdlOeztqg=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "72e2d02dbac80c8c86bf6bf3e785536acf8ee926",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
+        "owner": "ipetkov",
+        "repo": "crane",
         "type": "github"
       }
     },
@@ -39,24 +33,28 @@
     },
     "root": {
       "inputs": {
-        "fenix": "fenix",
-        "nixpkgs": "nixpkgs"
+        "crane": "crane",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
       }
     },
-    "rust-analyzer-src": {
-      "flake": false,
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1734765008,
-        "narHash": "sha256-dzjpge2mv+QVb3khpC7A4t4j3YC5EAE6DZ8NDjpLEFk=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "fda8b48bd82cc377318cafbfc5c3fdb630e8f105",
+        "lastModified": 1735352767,
+        "narHash": "sha256-3zXufMRWUdwmp8/BTmxVW/k4MyqsPjLnnt/IlQyZvhc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a16b9a7cac7f4d39a84234d62e91890370c57d76",
         "type": "github"
       },
       "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,31 +2,34 @@
   description = "git-sidequest";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    fenix = {
-      url = "github:nix-community/fenix";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
+    };
+    crane = {
+      url = "github:ipetkov/crane";
     };
   };
 
   outputs = {
     self,
     nixpkgs,
-    fenix,
+    crane,
+    rust-overlay,
   }: let
     pkgsFor = nixpkgs.legacyPackages;
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "x86_64-darwin" "aarch64-linux"];
   in {
     packages = forAllSystems (
       system: {
-        default = pkgsFor.${system}.callPackage ./default.nix {
-          fenix = fenix.packages.${system};
+        default = (pkgsFor.${system}.extend (import rust-overlay)).callPackage ./default.nix {
+          crane = crane;
         };
       }
     );
     devShells = forAllSystems (
       system: {
-        default = pkgsFor.${system}.callPackage ./shell.nix {
-          fenix = fenix.packages.${system};
+        default = (pkgsFor.${system}.extend (import rust-overlay)).callPackage ./shell.nix {
           inputs = self.inputs;
         };
       }

--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,14 @@
 {
   pkgs,
-  fenix,
   inputs,
 }:
 pkgs.mkShell {
   name = "git-sidequest";
-  inputsFrom = [(pkgs.callPackage ./default.nix {fenix = fenix;})];
+  inputsFrom = [
+    (pkgs.callPackage ./default.nix {
+      crane = inputs.crane;
+    })
+  ];
   # HACK: no-op value only used to make sure the flake inputs are not GC-ed
   # as long a profile of this flake is in the GCroots
   keepFlakeInputs = builtins.attrValues inputs;


### PR DESCRIPTION
## Description

- Migrate from `fenix` to `oxalica/rust-overlay` in order to have a faster initial toolchain setup
- Use `crane` instead of `buildRustPackage` to have saner opinionated defaults