### PR TITLE
rebase: cleanly rollback to the original state in case of merge conflict

### DIFF
--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -129,3 +129,14 @@ setup() {
     assert_failure
     assert_output --partial "No valid Git repository found"
 }
+
+@test "cleanly rollbacks if trying to sidequest a file that introduces merge conflicts" {
+    ORIGINAL_STATUS=$(git status)
+    git add file.txt
+    run $EXE_PATH sidequest-branch -m "This should not be commited"
+    assert_failure
+    assert_output --partial "Failed to rebase the sidequest branch onto the target branch, operation aborted"
+    assert_equal "$(git branch --show-current)" "original-branch"
+    git add sidequest.txt
+    assert_equal "$(git status)" "$ORIGINAL_STATUS"
+}


### PR DESCRIPTION
## Description

- Add a rollback process, to restore the repo to its original state if the rebase operation fails because of a merge conflict
- Add a test to cover this use case