### PR TITLE
ci: build Nix flake for all archs in CI

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,41 @@
+---
+name: Build Nix Flake
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v16
+        with:
+          name: git-sidequest
+          authToken: "${{ secrets.CACHIX_TOKEN }}"
+          extraPullNames: nix-community,devenv,crane
+      - run: nix flake check
+
+  build:
+    name: Build
+    strategy:
+      matrix:
+        os: ["ubuntu-24.04", "ubuntu-24.04-arm", "macos-13"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v16
+        with:
+          name: git-sidequest
+          authToken: "${{ secrets.CACHIX_TOKEN }}"
+          extraPullNames: nix-community,devenv,crane
+      - run: nix build .#

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,14 @@
     };
   };
 
+  nixConfig = {
+    extra-substituters = [
+      "https://git-sidequest.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "git-sidequest.cachix.org-1:r3uqOdmYrjjkuUNTcTBaGqFPPJ9nUdt3xtlcoljMyI4="
+    ];
+  };
   outputs = {
     self,
     nixpkgs,


### PR DESCRIPTION
# Description

Add a CI workflow that runs on all pushes to `master`, to check and build the Nix-based binary.